### PR TITLE
Update HttpClient.cpp

### DIFF
--- a/core/src/http/HttpClient.cpp
+++ b/core/src/http/HttpClient.cpp
@@ -176,7 +176,7 @@ HttpClient::HttpResponseOutcome HttpClient::SendRequest(const HttpRequest &reque
     {
     case CURLE_OK:
     {
-        int64_t response_code;
+        int64_t response_code = 0;
         curl_easy_getinfo(m_curlHandle, CURLINFO_RESPONSE_CODE, &response_code);
         response.SetStatusCode(response_code);
         response.SetBody(out.str());


### PR DESCRIPTION
修复 windows 下 CURLINFO_RESPONSE_CODE 获取返回值失败。该值必须初始化。