### PR TITLE
支持 macos

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -16,6 +16,11 @@
 
 configure_file(src/Config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/tencentcloud/core/Config.h @ONLY)
 
+set(uuid "uuid")
+if(NO_NEED_LIB_UUID)
+    set(uuid "")
+endif()
+
 set(core_public_header
     include/tencentcloud/core/AbstractClient.h
     include/tencentcloud/core/AbstractModel.h
@@ -100,7 +105,9 @@ set_target_properties(core
 target_include_directories(core
     PRIVATE include )
 
+
 target_link_libraries(core
+    ${uuid}
     ${OPENSSL_LIBRARIES}
     ${CURL_LIBRARIES} )
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -101,7 +101,6 @@ target_include_directories(core
     PRIVATE include )
 
 target_link_libraries(core
-    uuid
     ${OPENSSL_LIBRARIES}
     ${CURL_LIBRARIES} )
 


### PR DESCRIPTION
macos 下面，uuid 类库不需要 -luuid。

增加配置 `-DNO_NEED_LIB_UUID=true`，macos 下面顺利编译